### PR TITLE
Add notest option for cpanm

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -48,7 +48,7 @@ bash "install CPAN" do
   user "#{node[:cloudforecast][:user]}"
   environment 'HOME' => '/home/cloudforecast'
   code <<-EOH
-    cpanm -v -L extlib local::lib Module::Install CPAN CGI DBD::mysql JMX::Jmx4Perl
+    cpanm -v -L extlib --notest local::lib Module::Install CPAN CGI DBD::mysql JMX::Jmx4Perl
     cpanm -v -L extlib --installdeps --notest .
   EOH
 end


### PR DESCRIPTION
```
cpanm -v -L extlib local::lib Module::Install CPAN CGI DBD::mysql JMX::Jmx4Perl
```

が時間がかかりすぎてタイムアウト（3600sec）してしまうことがあり、`--notest`の追加でタイムアウトせずに正常終了を確認できた。
